### PR TITLE
Initial support for matrices

### DIFF
--- a/src/kesslerav/__init__.py
+++ b/src/kesslerav/__init__.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 from .constants import PROTOCOL_2K, SCHEME_TCP
 from .url_parser import parse_url
-from .media_switch import MediaSwitch
+from .media_switch import MediaSwitch,  MediaMatrix
 
 from .protocol2k import get_tcp_media_switch
 

--- a/src/kesslerav/__init__.py
+++ b/src/kesslerav/__init__.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 from .constants import PROTOCOL_2K, SCHEME_TCP
 from .url_parser import parse_url
-from .media_switch import MediaSwitch,  MediaMatrix
+from .media_switch import MediaSwitch
 
 from .protocol2k import get_tcp_media_switch
 
@@ -11,7 +11,7 @@ def get_media_switch(
     url: str,
     timeout_sec: Optional[float] = None,
     machine_id: Optional[int] = None
-  ) -> MediaSwitch:
+  ) -> list[MediaSwitch]:
   """
   Create media switch representation whose state can be accessed via the specified
   URL.
@@ -55,8 +55,8 @@ def get_media_switch(
       allows the underlying protocol driver to determine.
 
   Returns:
-    MediaSwitch: Representation of the media switch device, including methods for
-      controlling it (e.g., selecting sources.)
+    list[MediaSwitch]: Representation of the media switch device, including methods for
+      controlling it (e.g., selecting sources.). Each output of a matrix-type device is a MediaSwitch instance. Switches will have only one instance.
   """
   endpoint = parse_url(url)
   if endpoint.protocol == PROTOCOL_2K and endpoint.scheme == SCHEME_TCP:

--- a/src/kesslerav/media_switch.py
+++ b/src/kesslerav/media_switch.py
@@ -37,7 +37,7 @@ class MediaSwitch(Protocol):
   @property
   def is_locked(self) -> bool:
     """ Returns `true` when front panel is locked, `false` otherwise.
-    
+
     Note that the device can still be controlled remotely when front panel is
     locked.
     """
@@ -53,3 +53,16 @@ class MediaSwitch(Protocol):
     """
     Returns the number of outputs the switch has
     """
+
+
+class MediaMatrix(MediaSwitch):
+    def set_route(self, input: int, output: int) -> None:
+        """ Define a route, input to output """
+
+    @property
+    def selected_source(self, output: int) -> int:
+        """ Returns input number for given output """
+
+    @property
+    def routing_table(self):
+        """ Returns current matrix routing setup """

--- a/src/kesslerav/media_switch.py
+++ b/src/kesslerav/media_switch.py
@@ -35,6 +35,12 @@ class MediaSwitch(Protocol):
     """
 
   @property
+  def selected_audio_source(self) -> int:
+    """
+    Returns the input number of the selected audio source
+    """
+
+  @property
   def is_locked(self) -> bool:
     """ Returns `true` when front panel is locked, `false` otherwise.
 
@@ -53,16 +59,3 @@ class MediaSwitch(Protocol):
     """
     Returns the number of outputs the switch has
     """
-
-
-class MediaMatrix(MediaSwitch):
-    def set_route(self, input: int, output: int) -> None:
-        """ Define a route, input to output """
-
-    @property
-    def selected_source(self, output: int) -> int:
-        """ Returns input number for given output """
-
-    @property
-    def routing_table(self):
-        """ Returns current matrix routing setup """

--- a/src/kesslerav/protocol2k/__init__.py
+++ b/src/kesslerav/protocol2k/__init__.py
@@ -21,11 +21,11 @@ def get_tcp_media_switch(
     port: Optional[int] = None,
     timeout_sec: Optional[float] = None,
     machine_id: Optional[int] = None
-) -> list[MediaSwitchProtocol]:
-    if timeout_sec is None:
-        # Let `TcpEndpoint` manage timeout
-        endpoint = TcpEndpoint(host, port)
-    else:
-        endpoint = TcpEndpoint(host, port, timeout_sec)
-    tcp_device = TcpDevice(endpoint)
-    return get_switch_or_matrix(tcp_device, machine_id)
+  ) -> MediaSwitchProtocol:
+  if timeout_sec is None:
+    # Let `TcpEndpoint` manage timeout
+    endpoint = TcpEndpoint(host, port)
+  else:
+    endpoint = TcpEndpoint(host, port, timeout_sec)
+  tcp_device = TcpDevice(endpoint)
+  return get_switch_or_matrix(tcp_device, machine_id)

--- a/src/kesslerav/protocol2k/__init__.py
+++ b/src/kesslerav/protocol2k/__init__.py
@@ -5,23 +5,23 @@ from typing import Optional
 
 from ..media_switch import MediaSwitch as MediaSwitchProtocol
 from .io import TcpDevice, TcpEndpoint, Instruction, Command
-from .media_switch import MediaSwitch, MediaMatrix
+from .media_switch import MediaSwitch
 
 
 def get_switch_or_matrix(connection_device, machine_id):
     # Need to know output count early when setting up matrix, so get it here
     output_count = connection_device.process(Instruction(Command.DEFINE_MACHINE, 2, 1, machine_id))[0].output_value
     if output_count > 1:
-        return MediaMatrix(connection_device, output_count, machine_id)
+        return [MediaSwitch(connection_device, machine_id, output_count) for output_count in range(output_count)]
     else:
-        return MediaSwitch(connection_device, machine_id)
+        return [MediaSwitch(connection_device, machine_id)]
 
 def get_tcp_media_switch(
     host: str,
     port: Optional[int] = None,
     timeout_sec: Optional[float] = None,
     machine_id: Optional[int] = None
-) -> MediaSwitchProtocol:
+) -> list[MediaSwitchProtocol]:
     if timeout_sec is None:
         # Let `TcpEndpoint` manage timeout
         endpoint = TcpEndpoint(host, port)

--- a/src/kesslerav/protocol2k/__init__.py
+++ b/src/kesslerav/protocol2k/__init__.py
@@ -4,19 +4,28 @@ Encapsulates Protocol 2000 communication and devices
 from typing import Optional
 
 from ..media_switch import MediaSwitch as MediaSwitchProtocol
-from .io import TcpDevice, TcpEndpoint
-from .media_switch import MediaSwitch
+from .io import TcpDevice, TcpEndpoint, Instruction, Command
+from .media_switch import MediaSwitch, MediaMatrix
+
+
+def get_switch_or_matrix(connection_device, machine_id):
+    # Need to know output count early when setting up matrix, so get it here
+    output_count = connection_device.process(Instruction(Command.DEFINE_MACHINE, 2, 1, machine_id))[0].output_value
+    if output_count > 1:
+        return MediaMatrix(connection_device, output_count, machine_id)
+    else:
+        return MediaSwitch(connection_device, machine_id)
 
 def get_tcp_media_switch(
     host: str,
     port: Optional[int] = None,
     timeout_sec: Optional[float] = None,
     machine_id: Optional[int] = None
-  ) -> MediaSwitchProtocol:
-  if timeout_sec is None:
-    # Let `TcpEndpoint` manage timeout
-    endpoint = TcpEndpoint(host, port)
-  else:
-    endpoint = TcpEndpoint(host, port, timeout_sec)
-  tcp_device = TcpDevice(endpoint)
-  return MediaSwitch(tcp_device, machine_id)
+) -> MediaSwitchProtocol:
+    if timeout_sec is None:
+        # Let `TcpEndpoint` manage timeout
+        endpoint = TcpEndpoint(host, port)
+    else:
+        endpoint = TcpEndpoint(host, port, timeout_sec)
+    tcp_device = TcpDevice(endpoint)
+    return get_switch_or_matrix(tcp_device, machine_id)

--- a/src/kesslerav/protocol2k/io.py
+++ b/src/kesslerav/protocol2k/io.py
@@ -18,7 +18,8 @@ class Command(IntEnum):
   RECALL_VIDEO_STATUS = 4
   ERROR = 16
   PANEL_LOCK = 30
-  QUERY_OUTPUT_STATUS = 6 # Query audio status so we can transparently cope with audio only matrices - for video matrices the audio routing should always match the video routing
+  QUERY_VIDEO_OUTPUT_STATUS = 5
+  QUERY_AUDIO_OUTPUT_STATUS = 6
   QUERY_PANEL_LOCK = 31
   IDENTIFY_MACHINE = 61
   DEFINE_MACHINE = 62

--- a/src/kesslerav/protocol2k/io.py
+++ b/src/kesslerav/protocol2k/io.py
@@ -28,16 +28,12 @@ class Command(IntEnum):
   def is_supported(cls, cmd_id: int) -> bool:
     return cmd_id in iter(Command)
 
-
 # Validation rules: limit I/O values to one byte
 _VALUE_MIN = 0
 _VALUE_MAX = 128 # Only 7 bits available for data transport
 _VALID_RANGE: range = range(_VALUE_MIN, _VALUE_MAX)
 
-
-def _validated_value(
-    maybe_value: Optional[int],
-     default_value: int = 0) -> int:
+def _validated_value(maybe_value: Optional[int], default_value: int = 0) -> int:
   if maybe_value is None:
     return default_value
   if maybe_value not in _VALID_RANGE:
@@ -237,8 +233,7 @@ class TcpDevice:
     ):
     self._endpoint = endpoint
 
-  def process(self, instructions: list[Instruction]
-              | Instruction) -> list[Instruction]:
+  def process(self, instructions: list[Instruction] | Instruction) -> list[Instruction]:
     try:
       _ = iter(instructions)
     except TypeError:
@@ -271,21 +266,21 @@ class TcpDevice:
       instruction: Instruction,
       conn: socket.socket
     ) -> list[Instruction]:
-    req_bytes= Codec.encode(instruction)
+    req_bytes = Codec.encode(instruction)
     conn.send(req_bytes)
+
     # Device can return multiple instructions when its physical controls are
     # used. To capture them all (to reconstruct device state) we read using a
     # buffer that can hold multiple instructions and then return them all in
     # chronological event order.
-    result: list[Instruction]= []
+    result: list[Instruction] = []
     try:
       while len(result) < 1:
-        time.sleep(0.5) # Slow down to prevent 'port already in use' errors when interacting with serial over TCP TODO configurable, default off
-        data= conn.recv(TcpDevice.BUFFER_SIZE_BYTES)
-        responses= struct.iter_unpack(Instruction.FORMAT, data)
+        data = conn.recv(TcpDevice.BUFFER_SIZE_BYTES)
+        responses = struct.iter_unpack(Instruction.FORMAT, data)
         for response in responses:
-          resp_bytes= response[0].to_bytes(Instruction.SIZE_BYTES)
-          instruction= Codec.decode(resp_bytes)
+          resp_bytes = response[0].to_bytes(Instruction.SIZE_BYTES)
+          instruction = Codec.decode(resp_bytes)
           result.append(instruction)
     except TimeoutError:
       LOGGER.info(

--- a/src/kesslerav/protocol2k/media_switch.py
+++ b/src/kesslerav/protocol2k/media_switch.py
@@ -5,144 +5,136 @@ from ..media_switch import MediaSwitch as MediaSwitchProtocol
 from .io import Command, Instruction, TcpDevice
 
 class MediaSwitch(MediaSwitchProtocol):
-    def __init__(self, device: TcpDevice, machine_id: Optional[int] = None, output_number: Optional[int] = 1):
-        self._device = device
-        self._machine_id = machine_id
-        self._is_locked = False
-        self._selected_video_source = 0
-        self._selected_audio_source = 0
-        self._input_count = 0
-        self._output_count = 0
-        self._output_number = output_number # A matrix is represented by a MediaSwitch instance for each output.
-        self.update()
+  def __init__(self, device: TcpDevice, machine_id: Optional[int] = None, output_number: Optional[int] = 1):
+    self._device = device
+    self._machine_id = machine_id
+    self._is_locked = False
+    self._selected_source = 0
+    self._input_count = 0
+    self._output_count = 0
+    self._output_number = output_number # A matrix is represented by a MediaSwitch instance for each output.
+    self.update()
 
-    def _normalize_value(self, value):
-        if value < 0:
-            value = 0
-        elif value > self._input_count:
-            value = self._input_count
-        return value
+  def _normalize_value(self, value, limit):
+    if value < 0:
+        value = 0
+    elif value > limit:
+        value = limit
+    return value
 
-    def select_source(self, input: int) -> None:
-        """
-        Select the specified video and audio input
-        """
-        normalized_input = self._normalize_value(input)
-        instruction = Instruction(
-            Command.SWITCH_VIDEO,
-            normalized_input,
-            self._output_number+1, # We're counting from zero, the switch is counting from one
-            self._machine_id)
-        instruction = Instruction(
-            Command.SWITCH_AUDIO,
-            normalized_input,
-            self._output_number+1,
-            self._machine_id)
-        self._process(instruction)
-        self._selected_source = normalized_input
-        self._process(instruction)
+  def select_source(self, input: int) -> None:
+    """
+    Select the specified video and audio input
+    """
+    normalized_input = self._normalize_value(input)
+    instruction = Instruction(
+        Command.SWITCH_VIDEO,
+        normalized_input,
+        self._output_number+1, # We're counting from zero, the switch is counting from one
+        self._machine_id)
+    instruction = Instruction(
+        Command.SWITCH_AUDIO,
+        normalized_input,
+        self._output_number+1,
+        self._machine_id)
+    self._process(instruction)
+    self._selected_source = normalized_input
+    self._process(instruction)
 
-    def lock(self):
-        """
-        Lock panel
-        """
-        instruction = Instruction(
-            Command.PANEL_LOCK, 1, None, self._machine_id)
-        self._is_locked = True
-        self._process(instruction)
+  def lock(self):
+    """
+    Lock panel
+    """
+    instruction = Instruction(Command.PANEL_LOCK, 1, None, self._machine_id)
+    self._is_locked = True
+    self._process(instruction)
 
-    def unlock(self):
-        """
-        Unlock panel
-        """
-        instruction = Instruction(
-            Command.PANEL_LOCK, 0, None, self._machine_id)
-        self._is_locked = False
-        self._process(instruction)
+  def unlock(self):
+    """
+    Unlock panel
+    """
+    instruction = Instruction(Command.PANEL_LOCK, 0, None, self._machine_id)
+    self._is_locked = False
+    self._process(instruction)
 
-    def update(self) -> None:
-        self._process(self._update_instructions())
+  def update(self) -> None:
+    self._process(self._update_instructions())
 
-    @property
-    def selected_source(self) -> int:
-        """
-        Returns the input number of the selected source
-        """
-        return self._selected_video_source
+  @property
+  def selected_source(self) -> int:
+    """
+    Returns the input number of the selected source
+    """
+    return self._selected_video_source
 
-    @property
-    def selected_audio_source(self) -> int:
-        """
-        Returns the input number of the selected audio source
-        """
-        return self._selected_audio_source
+  @property
+  def selected_audio_source(self) -> int:
+    """
+    Returns the input number of the selected audio source
+    """
+    return self._selected_audio_source
 
-    @property
-    def input_count(self) -> int:
-        """
-        The number of inputs the switch has
-        """
-        return self._input_count
+  @property
+  def input_count(self) -> int:
+    """
+    The number of inputs the switch has
+    """
+    return self._input_count
 
-    @property
-    def output_count(self) -> int:
-        """
-        The number of outputs the switch has
-        """
-        return self._output_count
+  @property
+  def output_count(self) -> int:
+    """
+    The number of outputs the switch has
+    """
+    return self._output_count
 
-    @property
-    def is_locked(self) -> bool:
-        """
-        Returns `true` when panel is locked, `false` otherwise.
-        """
-        return self._is_locked
+  @property
+  def is_locked(self) -> bool:
+    """
+    Returns `true` when panel is locked, `false` otherwise.
+    """
+    return self._is_locked
 
-    @property
-    def machine_id(self) -> int | None:
-        return self._machine_id
+  @property
+  def machine_id(self) -> int | None :
+    return self._machine_id
 
-    def _process(self, instructions: list[Instruction] | Instruction) -> None:
-        results = self._device.process(instructions)
-        self._update_from_instructions(results)
+  def _process(self, instructions: list[Instruction] | Instruction) -> None:
+    results = self._device.process(instructions)
+    self._update_from_instructions(results)
 
-    def _update_from_instructions(
-            self, results: list[Instruction]) -> None:
-        for instruction in results:
-            match instruction.id:
-                case Command.DEFINE_MACHINE:
-                    if instruction.input_value == 1:
-                        self._input_count = instruction.output_value
-                    elif instruction.input_value == 2:
-                        self._output_count = instruction.output_value
-                case Command.PANEL_LOCK:
-                    self._is_locked = (instruction.input_value == 1)
-                case Command.SWITCH_VIDEO:
-                    self._selected_video_source = instruction.input_value
-                case Command.SWITCH_AUDIO:
-                    self._selected_audio_source = instruction.input_value
-                case Command.QUERY_VIDEO_OUTPUT_STATUS:
-                    self._selected_video_source = instruction.output_value
-                case Command.QUERY_AUDIO_OUTPUT_STATUS:
-                    self._selected_audio_source = instruction.output_value
-                case Command.QUERY_PANEL_LOCK:
-                    self._is_locked = (instruction.output_value == 1)
-                case _:
-                    LOGGER.info('Discarded instruction: %s', instruction)
+  def _update_from_instructions(self, instructions: list[Instruction]) -> None:
+    for instruction in results:
+        match instruction.id:
+            case Command.DEFINE_MACHINE:
+                if instruction.input_value == 1:
+                    self._input_count = instruction.output_value
+                elif instruction.input_value == 2:
+                    self._output_count = instruction.output_value
+            case Command.PANEL_LOCK:
+                self._is_locked = (instruction.input_value == 1)
+            case Command.SWITCH_VIDEO:
+                self._selected_video_source = instruction.input_value
+            case Command.SWITCH_AUDIO:
+                self._selected_audio_source = instruction.input_value
+            case Command.QUERY_VIDEO_OUTPUT_STATUS:
+                self._selected_video_source = instruction.output_value
+            case Command.QUERY_AUDIO_OUTPUT_STATUS:
+                self._selected_audio_source = instruction.output_value
+            case Command.QUERY_PANEL_LOCK:
+                self._is_locked = (instruction.output_value == 1)
+            case _:
+                LOGGER.info('Discarded instruction: %s', instruction)
 
-    def _update_instructions(self) -> list[Instruction]:
-        return [
-            # Queries the number of inputs
-            Instruction(Command.DEFINE_MACHINE, 1, 1, self._machine_id),
-            # Queries the number of outputs
-            Instruction(Command.DEFINE_MACHINE, 2, 1, self._machine_id),
-            # Queries which input is currently being routed to output represented by this instance (output one, if it's not a matrix switcher)
-            Instruction(Command.QUERY_VIDEO_OUTPUT_STATUS, 0, self._output_number, self._machine_id),
-            Instruction(Command.QUERY_AUDIO_OUTPUT_STATUS, 0, self._output_number, self._machine_id),
-            # Queries the panel lock status
-            Instruction(
-                Command.QUERY_PANEL_LOCK,
-                None,
-                None,
-                self._machine_id),
-        ]
+  def _update_instructions(self) -> list[Instruction]:
+    return [
+      # Queries the number of inputs
+      Instruction(Command.DEFINE_MACHINE, 1, 1, self._machine_id),
+      # Queries the number of outputs
+      Instruction(Command.DEFINE_MACHINE, 2, 1, self._machine_id),
+      # Queries which input is currently being routed to output represented by this instance (output one, if it's not a matrix switcher)
+      Instruction(Command.QUERY_VIDEO_OUTPUT_STATUS, 0, self._output_number, self._machine_id),
+      Instruction(Command.QUERY_AUDIO_OUTPUT_STATUS, 0, self._output_number, self._machine_id),
+      # Queries the panel lock status
+      Instruction(Command.QUERY_PANEL_LOCK, None, None, self._machine_id),
+    ]

--- a/src/kesslerav/protocol2k/media_switch.py
+++ b/src/kesslerav/protocol2k/media_switch.py
@@ -5,113 +5,194 @@ from ..media_switch import MediaSwitch as MediaSwitchProtocol
 from .io import Command, Instruction, TcpDevice
 
 class MediaSwitch(MediaSwitchProtocol):
-  def __init__(self, device: TcpDevice, machine_id: Optional[int] = None):
-    self._device = device 
-    self._machine_id = machine_id
-    self._is_locked = False
-    self._selected_source = 0
-    self._input_count = 0
-    self._output_count = 0
-    self.update()
+    def __init__(self, device: TcpDevice, machine_id: Optional[int] = None):
+        self._device = device
+        self._machine_id = machine_id
+        self._is_locked = False
+        self._selected_source = 0
+        self._input_count = 0
+        self._output_count = 0
+        self.update()
 
-  def select_source(self, input: int) -> None:
-    """
-    Select the specified video input
-    """
-    normalized_input = input
-    if normalized_input < 0:
-      normalized_input = 0
-    elif normalized_input > self._input_count:
-      normalized_input = self._input_count
+    def _normalize_value(self, value):
+        if value < 0:
+            value = 0
+        elif value > self._input_count:
+            value = self._input_count
+        return value
 
-    instruction = Instruction(Command.SWITCH_VIDEO, normalized_input, None, self._machine_id)
-    self._selected_source = normalized_input
-    self._process(instruction)
+    def select_source(self, input: int) -> None:
+        """
+        Select the specified video input
+        """
+        normalized_input = self._normalize_value(input)
+        instruction = Instruction(
+            Command.SWITCH_VIDEO,
+            normalized_input,
+            1,
+            self._machine_id)
+        self._selected_source = normalized_input
+        self._process(instruction)
 
-  def lock(self):
-    """
-    Lock panel
-    """
-    instruction = Instruction(Command.PANEL_LOCK, 1, None, self._machine_id)
-    self._is_locked = True
-    self._process(instruction)
+    def lock(self):
+        """
+        Lock panel
+        """
+        instruction = Instruction(
+            Command.PANEL_LOCK, 1, None, self._machine_id)
+        self._is_locked = True
+        self._process(instruction)
 
-  def unlock(self):
-    """
-    Unlock panel
-    """
-    instruction = Instruction(Command.PANEL_LOCK, 0, None, self._machine_id)
-    self._is_locked = False
-    self._process(instruction)
-  
-  def update(self) -> None:
-    self._process(self._update_instructions())
+    def unlock(self):
+        """
+        Unlock panel
+        """
+        instruction = Instruction(
+            Command.PANEL_LOCK, 0, None, self._machine_id)
+        self._is_locked = False
+        self._process(instruction)
 
-  @property
-  def selected_source(self) -> int:
-    """
-    Returns the input number of the selected source
-    """
-    return self._selected_source
+    def update(self) -> None:
+        self._process(self._update_instructions())
 
-  @property
-  def input_count(self) -> int:
-    """
-    The number of inputs the switch has
-    """
-    return self._input_count
+    @property
+    def selected_source(self) -> int:
+        """
+        Returns the input number of the selected source
+        """
+        return self._selected_source
 
-  @property
-  def output_count(self) -> int:
-    """
-    The number of outputs the switch has
-    """
-    return self._output_count
+    @property
+    def input_count(self) -> int:
+        """
+        The number of inputs the switch has
+        """
+        return self._input_count
 
-  @property
-  def is_locked(self) -> bool:
-    """
-    Returns `true` when panel is locked, `false` otherwise.
-    """
-    return self._is_locked
+    @property
+    def output_count(self) -> int:
+        """
+        The number of outputs the switch has
+        """
+        return self._output_count
 
-  @property
-  def machine_id(self) -> int | None :
-    return self._machine_id
+    @property
+    def is_locked(self) -> bool:
+        """
+        Returns `true` when panel is locked, `false` otherwise.
+        """
+        return self._is_locked
 
-  def _process(self, instructions: list[Instruction] | Instruction) -> None:
-    results = self._device.process(instructions)
-    self._update_from_instructions(results)
+    @property
+    def machine_id(self) -> int | None:
+        return self._machine_id
 
-  def _update_from_instructions(self, instructions: list[Instruction]) -> None:
-    for instruction in instructions:
-      match instruction.id:
-        case Command.DEFINE_MACHINE:
-          if instruction.input_value == 1:
-            self._input_count = instruction.output_value
-          elif instruction.input_value == 2:
-            self._output_count = instruction.output_value
-        case Command.PANEL_LOCK:
-          self._is_locked = (instruction.input_value == 1)
-        case Command.SWITCH_VIDEO:
-          self._selected_source = instruction.input_value
-        case Command.QUERY_OUTPUT_STATUS:
-          self._selected_source = instruction.output_value
-        case Command.QUERY_PANEL_LOCK:
-          self._is_locked = (instruction.output_value == 1)
-        case _:
-          LOGGER.info('Discarded instruction: %s', instruction)
-  
-  def _update_instructions(self) -> list[Instruction]:
-    return [
-      # Queries the number of inputs
-      Instruction(Command.DEFINE_MACHINE, 1, 1, self._machine_id),
-      # Queries the number of outputs
-      Instruction(Command.DEFINE_MACHINE, 2, 1, self._machine_id),
-      # Queries which input is currently being routed to output 1
-      Instruction(Command.QUERY_OUTPUT_STATUS, 0, 1, self._machine_id),
-      # Queries the panel lock status
-      Instruction(Command.QUERY_PANEL_LOCK, None, None, self._machine_id),
-    ]
+    def _process(self, instructions: list[Instruction] | Instruction) -> None:
+        results = self._device.process(instructions)
+        self._update_from_instructions(results)
+
+    def _update_from_instructions(
+            self, results: list[Instruction]) -> None:
+        for instruction in results:
+            match instruction.id:
+                case Command.DEFINE_MACHINE:
+                    if instruction.input_value == 1:
+                        self._input_count = instruction.output_value
+                    elif instruction.input_value == 2:
+                        self._output_count = instruction.output_value
+                case Command.PANEL_LOCK:
+                    self._is_locked = (instruction.input_value == 1)
+                case Command.SWITCH_VIDEO:
+                    self._selected_source = instruction.input_value
+                case Command.QUERY_OUTPUT_STATUS:
+                    self._selected_source = instruction.output_value
+                case Command.QUERY_PANEL_LOCK:
+                    self._is_locked = (instruction.output_value == 1)
+                case _:
+                    LOGGER.info('Discarded instruction: %s', instruction)
+
+    def _update_instructions(self) -> list[Instruction]:
+        return [
+            # Queries the number of inputs
+            Instruction(Command.DEFINE_MACHINE, 1, 1, self._machine_id),
+            # Queries the number of outputs
+            Instruction(Command.DEFINE_MACHINE, 2, 1, self._machine_id),
+            # Queries which input is currently being routed to output 1
+            Instruction(Command.QUERY_OUTPUT_STATUS, 0, 2, self._machine_id),
+            # Queries the panel lock status
+            Instruction(
+                Command.QUERY_PANEL_LOCK,
+                None,
+                None,
+                self._machine_id),
+        ]
 
 
+class MediaMatrix(MediaSwitch):
+    def __init__(self, device, output_count, machine_id: Optional[int] = None):
+        self._matrix = [0] * output_count
+        super().__init__(device, machine_id)
+        self._output_count = output_count
+
+    def set_route(self, input: int, output: int) -> None:
+        """
+        Select the specified input
+        """
+        normalized_input = self._normalize_value(input)
+        normalized_output = self._normalize_value(output)
+        instruction = Instruction(
+            Command.SWITCH_VIDEO,
+            normalized_input,
+            normalized_output,
+            self._machine_id)
+        self._process(instruction)
+        instruction = Instruction(
+            Command.SWITCH_AUDIO,
+            normalized_input,
+            normalized_output,
+            self._machine_id)
+        self._process(instruction)
+        self._matrix[output] = normalized_input
+
+    @property
+    def routing_table(self):
+        return self._matrix
+
+    def update(self) -> None:
+        super().update()
+        # Always update state of matrix each time because order can get scrambled otherwise TODO find a cleverer way...
+        for i in range(self.output_count):
+            self._matrix[i] = self._device.process(Instruction(Command.QUERY_OUTPUT_STATUS, 0, i+1, self._machine_id))[0].output_value
+
+
+    def _update_from_instructions(self, results: list[Instruction]) -> None:
+        for instruction in results:
+            match instruction.id:
+                case Command.DEFINE_MACHINE:
+                    if instruction.input_value == 1:
+                        self._input_count = instruction.output_value
+                    elif instruction.input_value == 2:
+                        self._output_count = instruction.output_value
+                case Command.PANEL_LOCK:
+                    self._is_locked = (instruction.input_value == 1)
+                case Command.SWITCH_VIDEO:
+                    self._matrix[instruction.output_value] = instruction.input_value
+                case Command.QUERY_PANEL_LOCK:
+                    self._is_locked = (instruction.output_value == 1)
+                case _:
+                    LOGGER.info('Discarded instruction: %s', instruction)
+
+    def _update_instructions(self) -> list[Instruction]:
+        instructions = [
+            # Queries the number of inputs
+            Instruction(Command.DEFINE_MACHINE, 1, 1, self._machine_id),
+            # Queries the number of outputs
+            Instruction(Command.DEFINE_MACHINE, 2, 1, self._machine_id),
+            # Queries the panel lock status
+            Instruction(
+                Command.QUERY_PANEL_LOCK,
+                None,
+                None,
+                self._machine_id),
+        ]
+        return instructions

--- a/src/kesslerav/protocol2k/media_switch.py
+++ b/src/kesslerav/protocol2k/media_switch.py
@@ -5,13 +5,15 @@ from ..media_switch import MediaSwitch as MediaSwitchProtocol
 from .io import Command, Instruction, TcpDevice
 
 class MediaSwitch(MediaSwitchProtocol):
-    def __init__(self, device: TcpDevice, machine_id: Optional[int] = None):
+    def __init__(self, device: TcpDevice, machine_id: Optional[int] = None, output_number: Optional[int] = 1):
         self._device = device
         self._machine_id = machine_id
         self._is_locked = False
-        self._selected_source = 0
+        self._selected_video_source = 0
+        self._selected_audio_source = 0
         self._input_count = 0
         self._output_count = 0
+        self._output_number = output_number # A matrix is represented by a MediaSwitch instance for each output.
         self.update()
 
     def _normalize_value(self, value):
@@ -23,14 +25,20 @@ class MediaSwitch(MediaSwitchProtocol):
 
     def select_source(self, input: int) -> None:
         """
-        Select the specified video input
+        Select the specified video and audio input
         """
         normalized_input = self._normalize_value(input)
         instruction = Instruction(
             Command.SWITCH_VIDEO,
             normalized_input,
-            1,
+            self._output_number+1, # We're counting from zero, the switch is counting from one
             self._machine_id)
+        instruction = Instruction(
+            Command.SWITCH_AUDIO,
+            normalized_input,
+            self._output_number+1,
+            self._machine_id)
+        self._process(instruction)
         self._selected_source = normalized_input
         self._process(instruction)
 
@@ -60,7 +68,14 @@ class MediaSwitch(MediaSwitchProtocol):
         """
         Returns the input number of the selected source
         """
-        return self._selected_source
+        return self._selected_video_source
+
+    @property
+    def selected_audio_source(self) -> int:
+        """
+        Returns the input number of the selected audio source
+        """
+        return self._selected_audio_source
 
     @property
     def input_count(self) -> int:
@@ -103,9 +118,13 @@ class MediaSwitch(MediaSwitchProtocol):
                 case Command.PANEL_LOCK:
                     self._is_locked = (instruction.input_value == 1)
                 case Command.SWITCH_VIDEO:
-                    self._selected_source = instruction.input_value
-                case Command.QUERY_OUTPUT_STATUS:
-                    self._selected_source = instruction.output_value
+                    self._selected_video_source = instruction.input_value
+                case Command.SWITCH_AUDIO:
+                    self._selected_audio_source = instruction.input_value
+                case Command.QUERY_VIDEO_OUTPUT_STATUS:
+                    self._selected_video_source = instruction.output_value
+                case Command.QUERY_AUDIO_OUTPUT_STATUS:
+                    self._selected_audio_source = instruction.output_value
                 case Command.QUERY_PANEL_LOCK:
                     self._is_locked = (instruction.output_value == 1)
                 case _:
@@ -117,8 +136,9 @@ class MediaSwitch(MediaSwitchProtocol):
             Instruction(Command.DEFINE_MACHINE, 1, 1, self._machine_id),
             # Queries the number of outputs
             Instruction(Command.DEFINE_MACHINE, 2, 1, self._machine_id),
-            # Queries which input is currently being routed to output 1
-            Instruction(Command.QUERY_OUTPUT_STATUS, 0, 2, self._machine_id),
+            # Queries which input is currently being routed to output represented by this instance (output one, if it's not a matrix switcher)
+            Instruction(Command.QUERY_VIDEO_OUTPUT_STATUS, 0, self._output_number, self._machine_id),
+            Instruction(Command.QUERY_AUDIO_OUTPUT_STATUS, 0, self._output_number, self._machine_id),
             # Queries the panel lock status
             Instruction(
                 Command.QUERY_PANEL_LOCK,
@@ -126,73 +146,3 @@ class MediaSwitch(MediaSwitchProtocol):
                 None,
                 self._machine_id),
         ]
-
-
-class MediaMatrix(MediaSwitch):
-    def __init__(self, device, output_count, machine_id: Optional[int] = None):
-        self._matrix = [0] * output_count
-        super().__init__(device, machine_id)
-        self._output_count = output_count
-
-    def set_route(self, input: int, output: int) -> None:
-        """
-        Select the specified input
-        """
-        normalized_input = self._normalize_value(input)
-        normalized_output = self._normalize_value(output)
-        instruction = Instruction(
-            Command.SWITCH_VIDEO,
-            normalized_input,
-            normalized_output,
-            self._machine_id)
-        self._process(instruction)
-        instruction = Instruction(
-            Command.SWITCH_AUDIO,
-            normalized_input,
-            normalized_output,
-            self._machine_id)
-        self._process(instruction)
-        self._matrix[output] = normalized_input
-
-    @property
-    def routing_table(self):
-        return self._matrix
-
-    def update(self) -> None:
-        super().update()
-        # Always update state of matrix each time because order can get scrambled otherwise TODO find a cleverer way...
-        for i in range(self.output_count):
-            self._matrix[i] = self._device.process(Instruction(Command.QUERY_OUTPUT_STATUS, 0, i+1, self._machine_id))[0].output_value
-
-
-    def _update_from_instructions(self, results: list[Instruction]) -> None:
-        for instruction in results:
-            match instruction.id:
-                case Command.DEFINE_MACHINE:
-                    if instruction.input_value == 1:
-                        self._input_count = instruction.output_value
-                    elif instruction.input_value == 2:
-                        self._output_count = instruction.output_value
-                case Command.PANEL_LOCK:
-                    self._is_locked = (instruction.input_value == 1)
-                case Command.SWITCH_VIDEO:
-                    self._matrix[instruction.output_value] = instruction.input_value
-                case Command.QUERY_PANEL_LOCK:
-                    self._is_locked = (instruction.output_value == 1)
-                case _:
-                    LOGGER.info('Discarded instruction: %s', instruction)
-
-    def _update_instructions(self) -> list[Instruction]:
-        instructions = [
-            # Queries the number of inputs
-            Instruction(Command.DEFINE_MACHINE, 1, 1, self._machine_id),
-            # Queries the number of outputs
-            Instruction(Command.DEFINE_MACHINE, 2, 1, self._machine_id),
-            # Queries the panel lock status
-            Instruction(
-                Command.QUERY_PANEL_LOCK,
-                None,
-                None,
-                self._machine_id),
-        ]
-        return instructions


### PR DESCRIPTION
Hey - love the work :D I'm in the process of integrating a VS-88A 8x8 audio matrix into HA. I've dropped the serial support I initially wrote as I'm now using ser2net to bridge the serial connection to the existing TCP endpoint, which seems to work quite okay - except for the speed, as per the forced slowdown I've had to stick in. This is one of the things I want to discuss with yourself and find a better solution for. 

The other big thing is currently I'm having to poll the full state of the matrix super often, but I haven't been able to find a smarter way to do so since a single Protocol2000 'REQUEST STATUS' instruction doesn't describe a full route - you need the following:
1. Send 'REQUEST STATUS' with output value equal to output number one is requesting status for
2. Unit replies with 'REQUEST STATUS' with output value equal to the input number that output is routed for 

Unfortunately, there's no easy way, as far as I can tell, to 'match' the two instructions from information contained within the instructions themselves. 

Apologies about some of the rogue whitespace edits, I accidentally ran a formatter from a different project over some of the files I edited and am having to manually revert. :/ But wanted to get this PR up as a draft to start the discussion over the above points. 